### PR TITLE
Expanded plotting options for `ChemicalPotentialPlot.plot_phase()`

### DIFF
--- a/surfinpy/chemical_potential_plot.py
+++ b/surfinpy/chemical_potential_plot.py
@@ -50,7 +50,8 @@ class ChemicalPotentialPlot:
         figsize : tuple (optional)
             Set a custom figure size. Default=None
         """
-        plt.style.use(set_style)
+        if set_style:
+            plt.style.use(set_style)
         levels = ut.get_levels(self.z)
         ticky = ut.get_ticks(self.ticks)
         temperature_label = str(temperature) + " K"
@@ -92,7 +93,8 @@ class ChemicalPotentialPlot:
         colourmap : str
             colourmap for the plot
         """
-        plt.style.use(set_style)
+        if set_style:
+            plt.style.use(set_style)
         p1 = ut.pressure(self.x, temperature)
         p2 = ut.pressure(self.y, temperature)
         temperature_label = str(temperature) + " K"
@@ -140,7 +142,8 @@ class ChemicalPotentialPlot:
         colourmap : str
             colourmap for the plot
         """
-        plt.style.use(set_style)
+        if set_style:
+            plt.style.use(set_style)
         p1 = ut.pressure(self.x, temperature)
         p2 = ut.pressure(self.y, temperature)
         temperature_label = str(temperature) + " K"

--- a/surfinpy/chemical_potential_plot.py
+++ b/surfinpy/chemical_potential_plot.py
@@ -31,24 +31,28 @@ class ChemicalPotentialPlot:
         self.xlabel = xlabel
         self.ylabel = ylabel
 
-    def plot_phase(self, temperature=None, xlabel=None, ylabel=None, output="phase.png", colourmap="viridis",
-                   set_style="default", figsize=None):
+    def plot_phase(self, temperature=None, xlabel=None, ylabel=None, output="phase.png", 
+                   colourmap="viridis", set_style="default", figsize=None, show_fig=True):
         """Plots a simple phase diagram as a function of chemical potential.
 
         Parameters
         ----------
-        temperature : int (optional)
+        temperature: int (optional)
             Temperature. Default=None
         xlabel: str (optional)
             Set a custom x-axis label. Default=None
         ylabel: str (optional)
             Set a custom y-axis label. Default=None
-        output : str (optional)
+        output: str (optional)
             Output filename. Default='phase.png'
-        colourmap : str (optional)
+            If output is set to `None`, no output is generated.
+        colourmap: str (optional)
             Colourmap for the plot. Default='viridis'
-        figsize : tuple (optional)
+        figsize: tuple (optional)
             Set a custom figure size. Default=None
+        show_fig: bool (optional)
+            Automatically display a figure. Default=True
+            If set to False the plot is returned as an object.
         """
         if set_style:
             plt.style.use(set_style)
@@ -76,8 +80,12 @@ class ChemicalPotentialPlot:
         cbar = fig.colorbar(CM, ticks=ticky, pad=0.1)
         cbar.ax.set_yticklabels(self.labels)
         plt.tight_layout()
-        plt.savefig(output, dpi=600)
-        plt.show()
+        if output:
+            plt.savefig(output, dpi=600)
+        if show_fig:
+            plt.show()
+        else:
+            return ax
 
     def plot_mu_p(self, temperature, output="phase.png", colourmap="viridis",
                   set_style="default"):

--- a/surfinpy/pvt_plot.py
+++ b/surfinpy/pvt_plot.py
@@ -30,7 +30,8 @@ class PVTPlot:
         atmospheric_conditions : list
             location of bars showing atmospheric conditions
         """
-        plt.style.use(set_style)
+        if set_style:
+            plt.style.use(set_style)
         fig = plt.figure()
         ax = fig.add_subplot(111)
         ax.contourf(self.x, self.y, self.z, cmap=colourmap)        


### PR DESCRIPTION
This commit adds some optional arguments to the `ChemicalPotentialPlot.plot_phase()` method.

 - `show_fig`: Defaults to `True` (original default behaviour to automatically display a figure). If set to `False` a figure is not automatically shown, and the current `Axes` object is returned for further manipulation.
- `output`: Now, if this is set to `None`, no output file is generated (allowing further editing of the figure using `show_fig=False` before saving.

e.g. to edit tick marks *outside* of `surfinpy`:

```python
cpp = ChemicalPotentialPlot(x=x_grid, y=y_grid, z=z, 
                            labels=['V+V', 'V+Li', 'V+Mg', 'Li+Li', 'Mg+Mg', 'Li+Mg'], 
                            ticks=np.arange(6), xlabel='Li', ylabel='Mg')

ax = cpp.plot_phase(xlabel='$\Delta \widetilde{\mu}_{\mathrm{Li}}$ [eV]', 
                    ylabel='$\Delta \widetilde{\mu}_{\mathrm{Mg}}$ [eV]',
                    figsize=(5.5,4.2),
                    output=None,
                    colourmap='Blues',
                    set_style=None,
                    show_fig=False)
ax.set_yticks(np.arange(-4,4,2))
plt.savefig('output.pdf')
plt.show()
```