### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/source/bulk_theory.rst
+++ b/docs/source/bulk_theory.rst
@@ -1,8 +1,8 @@
 Bulk Theory
 ===========
 
-Bulk phase diagrams enable the comparison of the thermodynamic stability of various different bulk phases under different chemical potentials giving valuable insight in to the syntheis of solid phases.  
-This theory example will consider a series of bulk phases which can be defined through a reaction scheme across all phases, 
+Bulk phase diagrams enable the comparison of the thermodynamic stability of various different bulk phases under different chemical potentials giving valuable insight in to the synthesis of solid phases.
+This theory example will consider a series of bulk phases which can be defined through a reaction scheme across all phases,
 thus for this example including MgO, :math:`H_2O` and :math:`CO_2` as reactions and A as a generic product.
 
 .. math::
@@ -18,12 +18,12 @@ Assuming that :math:`H_2O` and :math:`CO_2` are gaseous species, :math:`$\mu_{CO
 .. math::
 	\mu_{\text{H}_2\text{O}} = \mu^0_{\text{H}_2\text{O}} + \Delta\mu_{\text{H}_2\text{O}}
 
-and 
+and
 
 .. math::
 	\mu_{\text{CO}_2} = \mu^0_{\text{CO}_2} + \Delta\mu_{\text{CO}_2}
 
-The chemical potential :math:`$\mu^0_x$` is the partial molar free energy of any reactants or products (x) in their standard states, 
+The chemical potential :math:`$\mu^0_x$` is the partial molar free energy of any reactants or products (x) in their standard states,
 in this example we assume all solid components can be expressed as
 
 .. math::
@@ -44,8 +44,8 @@ At equilibrium :math:`$\delta G_{T,p} = 0$`, and hence
 .. math::
 	\Delta G_{\text{f}}^0 = y\Delta\mu_{\text{H}_2\text{O}} + z\Delta\mu_{\text{CO}_2}
 
-Thus, we can find the values of :math:`$\Delta\mu_{H_2O}$` and :math:`$\Delta\mu_{CO_2}$` (or :math:`$(p_{H_2O})^y$` and :math:`$p_{CO_2}^z$` when Mg-rich phases are in thermodynamic equilibrium; i.e. 
-they are more or less stable than MgO.  
+Thus, we can find the values of :math:`$\Delta\mu_{H_2O}$` and :math:`$\Delta\mu_{CO_2}$` (or :math:`$(p_{H_2O})^y$` and :math:`$p_{CO_2}^z$` when Mg-rich phases are in thermodynamic equilibrium; i.e.
+they are more or less stable than MgO.
 This procedure can then be applied to all phases to identify which is the most stable, provided that the free energy :math:`$\Delta G_f^0$` is known for each Mg-rich phase.
 
 The free energy can be calculated using
@@ -58,16 +58,16 @@ Where for this example the free energy (G) is equal to the calculated DFT energy
 Temperature
 ~~~~~~~~~~~
 
-The previous method will generate a phase diagram at 0 K. This is not representative of normal conditions.  
-Temperature is an important consideration for materials chemistry and we may wish to evaluate the phase thermodynamic stability at various synthesis conditions.  
+The previous method will generate a phase diagram at 0 K. This is not representative of normal conditions.
+Temperature is an important consideration for materials chemistry and we may wish to evaluate the phase thermodynamic stability at various synthesis conditions.
 
 As before the free energy can be calculated using;
 
 .. math::
     \Delta G^{0}_{f} = \sum\Delta G_{f}^{0,\text{products}} - \sum\Delta G_{f}^{0,\text{reactants}}
 
-Where for this exmaple the free energy (G) for solid phases is equal to is equal to the calculated DFT energy :math:`(U_0)`. 
-For gaseous species, the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems, 
+Where for this example the free energy (G) for solid phases is equal to is equal to the calculated DFT energy :math:`(U_0)`.
+For gaseous species, the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems,
 we use experimental data to determine the temperature dependent free energy term for gaseous species, where :math:`$S_{expt}(T)$` is specific entropy value for a given T and  :math:`$H-H^0(T)$` is the,
 both can be obtained from the NIST database and can be calculated as;
 
@@ -77,12 +77,12 @@ both can be obtained from the NIST database and can be calculated as;
 Pressure
 --------
 
-In the previous tutorials we went through the process of generating a simple phase diagram for bulk phases and introducing temperature dependence for gaseous species.  
-This useful however, sometimes it can be more beneficial to convert the chemical potenials (eVs) to partial presure (bar). 
+In the previous tutorials we went through the process of generating a simple phase diagram for bulk phases and introducing temperature dependence for gaseous species.
+This useful however, sometimes it can be more beneficial to convert the chemical potentials (eVs) to partial pressure (bar).
 
 Chemical potential can be converted to pressure values using
 
 .. math::
     P & = \frac{\mu_O}{k_B T} ,
 
-where P is the pressure, :math:`$\mu$` is the chemical potential of oxygen, $k_B$ is the Boltzmnann constant and T is the temperature. 
+where P is the pressure, :math:`$\mu$` is the chemical potential of oxygen, $k_B$ is the Boltzmann constant and T is the temperature.

--- a/docs/source/surface_theory.rst
+++ b/docs/source/surface_theory.rst
@@ -1,23 +1,23 @@
 Surface Theory
 ==============
 
-`surfinpy` has the capability to generate phase diagrams as a function of chemical potential of two varying species e.g. water and carbon dioxide. In such an example 
-the user would require calculations with varying concentrations of water, carbon dioxide and water/carbon dioxide on a surface. Assuming that you have generated enough, 
+`surfinpy` has the capability to generate phase diagrams as a function of chemical potential of two varying species e.g. water and carbon dioxide. In such an example
+the user would require calculations with varying concentrations of water, carbon dioxide and water/carbon dioxide on a surface. Assuming that you have generated enough,
 reliable data then you are ready to use `surfinpy`.
 
 Surface Energy
 ~~~~~~~~~~~~~~
 
-The physical quantity that is used to define the stability of a surface with a given composition is its surface energy :math:`\gamma` (J :math:`m^{-2}`). 
-At its core, `surfinpy` is a code that calculates the surface energy of different slabs at varying chemical potential and 
+The physical quantity that is used to define the stability of a surface with a given composition is its surface energy :math:`\gamma` (J :math:`m^{-2}`).
+At its core, `surfinpy` is a code that calculates the surface energy of different slabs at varying chemical potential and
 uses these surface energies to construct a phase diagram.
-In this explantion of theory we will use the example of water adsorbing onto a surface of :math:`TiO_2` containing oxygen vacancies.
-In such an example there are two variables, water concentration and oxygen concentration. We are able to calculate the surface energy according to 
+In this explanation of theory we will use the example of water adsorbing onto a surface of :math:`TiO_2` containing oxygen vacancies.
+In such an example there are two variables, water concentration and oxygen concentration. We are able to calculate the surface energy according to
 
 .. math::
     \gamma_{Surf} = \frac{1}{2A} \Bigg( E_{TiO_2}^{slab} - \frac{nTi_{slab}}{nTi_{Bulk}} E_{TiO_2}^{Bulk} \Bigg) - \Gamma_O \mu_O - \Gamma_{H_2O} \mu_{H_2O} ,
 
-where A is the surface area, :math:`E_{TiO_2}^{slab}` is the DFT energy of the slab, :math:`nTi_{Slab}` is the number of cations in the slab, 
+where A is the surface area, :math:`E_{TiO_2}^{slab}` is the DFT energy of the slab, :math:`nTi_{Slab}` is the number of cations in the slab,
 :math:`nTi_{Bulk}` is the number of cations in the bulk unit cell, :math:`E_{TiO_2}^{Bulk}` is the DFT energy of the bulk unit cell,
 
 .. math::
@@ -26,9 +26,9 @@ where A is the surface area, :math:`E_{TiO_2}^{slab}` is the DFT energy of the s
 .. math::
     \Gamma_{H_2O} = \frac{nH_2O}{2A},
 
-where :math:`nO_{Slab}` is the number of anions in the slab, :math:`nO_{Bulk}` is the number of anions in the bulk and :math:`nH_2O` is the number of adsorbing water molecules. 
-:math:`\Gamma_O` / :math:`\Gamma_{H_2O}` is the excess oxygen / water at the surface and :math:`\mu_O` / :math:`\mu_{H_2O}` is the oxygen / water chemcial potential. 
-Clearly :math:`\Gamma` and :math:`mu` will only matter when the surface is non stoichiometric. 
+where :math:`nO_{Slab}` is the number of anions in the slab, :math:`nO_{Bulk}` is the number of anions in the bulk and :math:`nH_2O` is the number of adsorbing water molecules.
+:math:`\Gamma_O` / :math:`\Gamma_{H_2O}` is the excess oxygen / water at the surface and :math:`\mu_O` / :math:`\mu_{H_2O}` is the oxygen / water chemical potential.
+Clearly :math:`\Gamma` and :math:`mu` will only matter when the surface is non stoichiometric.
 
 Temperature
 ~~~~~~~~~~~
@@ -37,14 +37,14 @@ The above phase diagram is at 0K. It is possible to use experimental data from t
 term and thus generate a phase diagram at a temperature (T). This is done according to
 
 .. math::
-    \gamma_{Surf} = \frac{1}{2A} \Bigg( E_{TiO_2}^{slab} - \frac{nTi_{Slab}}{nTi_{Bulk}} E_{TiO_2}^{Bulk} \Bigg) - \Gamma_O \mu_O - \Gamma_{H_2O} \mu_{H_2O} - n_O \mu_O (T) - n_{H_2O} \mu_{H_2O} (T) 
+    \gamma_{Surf} = \frac{1}{2A} \Bigg( E_{TiO_2}^{slab} - \frac{nTi_{Slab}}{nTi_{Bulk}} E_{TiO_2}^{Bulk} \Bigg) - \Gamma_O \mu_O - \Gamma_{H_2O} \mu_{H_2O} - n_O \mu_O (T) - n_{H_2O} \mu_{H_2O} (T)
 
-where 
+where
 
 .. math::
     \mu_O (T)  = \frac{1}{2} \mu_O (T) (0 K , DFT) +  \frac{1}{2} \mu_O (T) (0 K , EXP) +  \frac{1}{2} \Delta G_{O_2} ( \Delta T, Exp),
 
-:math:`\mu_O` (T) (0 K , DFT) is the 0K free energy of an isolated oxygen molecule evaluated with DFT, :math:`\mu_O` (T) (0 K , EXP) is the 0 K experimental 
+:math:`\mu_O` (T) (0 K , DFT) is the 0K free energy of an isolated oxygen molecule evaluated with DFT, :math:`\mu_O` (T) (0 K , EXP) is the 0 K experimental
 Gibbs energy for oxygen gas and $\Delta$ :math:`G_{O_2}` ( :math:`\Delta` T, Exp) is the Gibbs energy defined at temperature T as
 
 .. math::
@@ -60,24 +60,24 @@ Chemical potential can be converted to pressure values according to
 .. math::
     P = \frac{\mu_X}{k_B T}
 
-where P is the pressure, :math:`\mu` is the chemical potential of species X, :math:`k_B` is the Boltzmnann constant and T is the temperature. 
+where P is the pressure, :math:`\mu` is the chemical potential of species X, :math:`k_B` is the Boltzmann constant and T is the temperature.
 
 Pressure vs temperature
 ~~~~~~~~~~~~~~~~~~~~~~~
- 
-`Surfinpy` has the functionality to generate phase diagrams as a function of pressure vs temperature based upon the methodology used in `Molinari et al 
+
+`Surfinpy` has the functionality to generate phase diagrams as a function of pressure vs temperature based upon the methodology used in `Molinari et al
 <https://pubs.acs.org/doi/abs/10.1021/jp300576b>`_ according to
 
 .. math::
     \gamma_{adsorbed, T, P} = \gamma_{bare} + ( C ( E_{ads, T} - RTln(\frac{p}{p^o})
 
-where :math:`\gamma_{adsorbed, T, p}` is the surface energy of the surface with adsorbed species at temperature (T) and pressure (P), 
-:math:`\gamma_{bare}` is the suface energy of the bare surface, C is the coverage of adsorbed species, :math:`E_{ads}` is the adsorption energy, 
+where :math:`\gamma_{adsorbed, T, p}` is the surface energy of the surface with adsorbed species at temperature (T) and pressure (P),
+:math:`\gamma_{bare}` is the surface energy of the bare surface, C is the coverage of adsorbed species, :math:`E_{ads}` is the adsorption energy,
 
 .. math::
     E_{ads, T} =  E_{slab, adsorbant} - (E_{slab, bare} + n_{H_2O} E_{H_2O, T}) / n_{H_2O}
 
-where :math:`E_{slab, adsorbant}` is the energy of the surface and the adsorbed species, :math:`n_{H_2O}` is he number of adsorbed species, 
+where :math:`E_{slab, adsorbant}` is the energy of the surface and the adsorbed species, :math:`n_{H_2O}` is he number of adsorbed species,
 
 .. math::
     E_{H_2O, (T)} = E_{H_2O, (g)} - TS_{(T)}

--- a/docs/source/tutorial_1.rst
+++ b/docs/source/tutorial_1.rst
@@ -1,15 +1,15 @@
 Chemical Potential
 ==================
 
-The physical quantity that is used to define the stability of a surface with a given composition is its surface energy :math:`\gamma` (J :math:`m^{-2}`). 
+The physical quantity that is used to define the stability of a surface with a given composition is its surface energy :math:`\gamma` (J :math:`m^{-2}`).
 At its core, `surfinpy` is a code that calculates the surface energy of different slabs and uses these surface energies to build a phase diagram.
-In this explantion of theory we will use the example of water adsorbing onto a surface of :math:`TiO_2` containing oxygen vacancies.
-In such an example there are two variables, water concentration and oxygen vacancy concentration. We are able to calculate the surface energy according to 
+In this explanation of theory we will use the example of water adsorbing onto a surface of :math:`TiO_2` containing oxygen vacancies.
+In such an example there are two variables, water concentration and oxygen vacancy concentration. We are able to calculate the surface energy according to
 
 .. math::
     \gamma_{Surf} = \frac{1}{2A} \Bigg( E_{TiO_2}^{slab} - \frac{nTi_{slab}}{nTi_{Bulk}} E_{TiO_2}^{Bulk} \Bigg) - \Gamma_O \mu_O - \Gamma_{H_2O} \mu_{H_2O} ,
 
-where A is the surface area, :math:`E_{TiO_2}^{slab}` is the DFT energy of the slab, :math:`nTi_{Slab}` is the number of cations in the slab, 
+where A is the surface area, :math:`E_{TiO_2}^{slab}` is the DFT energy of the slab, :math:`nTi_{Slab}` is the number of cations in the slab,
 :math:`nTi_{Bulk}` is the number of cations in the bulk unit cell, :math:`E_{TiO_2}^{Bulk}` is the DFT energy of the bulk unit cell and
 
 .. math::
@@ -18,28 +18,28 @@ where A is the surface area, :math:`E_{TiO_2}^{slab}` is the DFT energy of the s
 .. math::
     \Gamma_{H_2O} = \frac{nH_2O}{2A} ,
 
-where :math:`nO_{Slab}` is the number of anions in the slab, :math:`nO_{Bulk}` is the number of anions in the bulk and :math:`nH_2O` is the number of adsorbing water molecules. 
-:math:`\Gamma_O` / :math:`\Gamma_{H_2O}` is the excess oxygen / water at the surface and :math:`\mu_O` / :math:`\mu_{H_2O}` is the oxygen / water chemcial potential. 
-Clearly :math:`\Gamma` and :math:`mu` will only matter when the surface is non stoichiometric. 
+where :math:`nO_{Slab}` is the number of anions in the slab, :math:`nO_{Bulk}` is the number of anions in the bulk and :math:`nH_2O` is the number of adsorbing water molecules.
+:math:`\Gamma_O` / :math:`\Gamma_{H_2O}` is the excess oxygen / water at the surface and :math:`\mu_O` / :math:`\mu_{H_2O}` is the oxygen / water chemical potential.
+Clearly :math:`\Gamma` and :math:`mu` will only matter when the surface is non stoichiometric.
 
 Usage
 ~~~~~
 
-The first thing to do is input the data that we have generated from our DFT calculations. 
+The first thing to do is input the data that we have generated from our DFT calculations.
 The input data needs to be contained within a dictionary.
-First we have created the dictionary for the bulk data, where ``Cation`` is the number of cations, ``Anion`` is the number of anions, 
+First we have created the dictionary for the bulk data, where ``Cation`` is the number of cations, ``Anion`` is the number of anions,
 ``Energy`` is the DFT energy and ``F-Units`` is the number of formula units.
 
 .. code-block:: python
 
-    bulk = {'Cation' : Cations in Bulk Unit Cell, 
-            'Anion' : Anions in Bulk Unit Cell, 
-            'Energy' :  Energy of Bulk Calculation, 
+    bulk = {'Cation' : Cations in Bulk Unit Cell,
+            'Anion' : Anions in Bulk Unit Cell,
+            'Energy' :  Energy of Bulk Calculation,
             'F-Units' : Formula units in Bulk Calculation}
 
-Next we create the slab dictionaries - one for each slab calculation or "phase". ``Cation`` is the number of cations, 
-``X`` is in this case the number of oxygen species (corresponding to the X axis of the phase diagram), 
-``Y`` is the number of in this case water molecules (corresponding to the Y axis of our phase diagram), 
+Next we create the slab dictionaries - one for each slab calculation or "phase". ``Cation`` is the number of cations,
+``X`` is in this case the number of oxygen species (corresponding to the X axis of the phase diagram),
+``Y`` is the number of in this case water molecules (corresponding to the Y axis of our phase diagram),
 ``Area`` is the surface area, ``Energy`` is the DFT energy, ``Label`` is the label for the surface (appears on the phase diagram) and
 finally ``nSpecies`` is the number of adsorbing species (In this case we have a surface with oxygen vacancies and adsorbing water molecules -
 so nSpecies is 1 as oxygen vacancies are not an adsorbing species, they are a constituent part of the surface).
@@ -47,7 +47,7 @@ so nSpecies is 1 as oxygen vacancies are not an adsorbing species, they are a co
 .. code-block:: python
 
     surface = {'Cation': Cations in Slab,
-               'X': Number of Species X in Slab, 
+               'X': Number of Species X in Slab,
                'Y': Number of Species Y in Slab,
                'Area': Surface area in the slab,
                'Energy': Energy of Slab,
@@ -55,10 +55,10 @@ so nSpecies is 1 as oxygen vacancies are not an adsorbing species, they are a co
                'nSpecies': How many species are non stoichiometric}
 
 
-This data needs to be contained within a list. Don't worry about the order, `surfinpy` will sort that out for you. 
+This data needs to be contained within a list. Don't worry about the order, `surfinpy` will sort that out for you.
 
-We also need to declare the range in chemical potential that we want to consider. 
-Again these exist in a dictionary. ``Range`` corresponds to the range of chemcial potential values to be considered and ``Label`` is the axis label.
+We also need to declare the range in chemical potential that we want to consider.
+Again these exist in a dictionary. ``Range`` corresponds to the range of chemical potential values to be considered and ``Label`` is the axis label.
 
 .. code-block:: python
 
@@ -76,19 +76,19 @@ Again these exist in a dictionary. ``Range`` corresponds to the range of chemcia
                 'Energy': -575.0,   'Label': 'Stoich',  'nSpecies': 1}
     H2O =      {'Cation': 24, 'X': 48, 'Y': 2, 'Area': 60.0,
                 'Energy': -612.0,   'Label': '1 Water', 'nSpecies': 1}
-    H2O_2 =    {'Cation': 24, 'X': 48, 'Y': 4, 'Area': 60.0, 
+    H2O_2 =    {'Cation': 24, 'X': 48, 'Y': 4, 'Area': 60.0,
                 'Energy': -640.0,   'Label': '2 Water', 'nSpecies': 1}
     H2O_3 =    {'Cation': 24, 'X': 48, 'Y': 8, 'Area': 60.0,
                 'Energy': -676.0,   'Label': '3 Water', 'nSpecies': 1}
-    Vo =       {'Cation': 24, 'X': 46, 'Y': 0, 'Area': 60.0, 
+    Vo =       {'Cation': 24, 'X': 46, 'Y': 0, 'Area': 60.0,
                 'Energy': -558.0,   'Label': 'Vo', 'nSpecies': 1}
-    H2O_Vo =   {'Cation': 24, 'X': 46, 'Y': 2, 'Area': 60.0, 
+    H2O_Vo =   {'Cation': 24, 'X': 46, 'Y': 2, 'Area': 60.0,
                 'Energy': -594.0,  'Label': 'Vo + 1 Water', 'nSpecies': 1}
-    H2O_Vo_2 = {'Cation': 24, 'X': 46, 'Y': 4, 'Area': 60.0, 
+    H2O_Vo_2 = {'Cation': 24, 'X': 46, 'Y': 4, 'Area': 60.0,
                 'Energy': -624.0,  'Label': 'Vo + 2 Water', 'nSpecies': 1}
-    H2O_Vo_3 = {'Cation': 24, 'X': 46, 'Y': 6, 'Area': 60.0, 
+    H2O_Vo_3 = {'Cation': 24, 'X': 46, 'Y': 6, 'Area': 60.0,
                 'Energy': -640.0, 'Label': 'Vo + 3 Water', 'nSpecies': 1}
-    H2O_Vo_4 = {'Cation': 24, 'X': 46, 'Y': 8, 'Area': 60.0, 
+    H2O_Vo_4 = {'Cation': 24, 'X': 46, 'Y': 8, 'Area': 60.0,
                 'Energy': -670.0, 'Label': 'Vo + 4 Water', 'nSpecies': 1}
 
     data = [pure, H2O_2, H2O_Vo, H2O,  H2O_Vo_2, H2O_3, H2O_Vo_3,  H2O_Vo_4, Vo]
@@ -115,20 +115,20 @@ The previous phase diagram is at 0K. It is possible to use experimental data fro
 term and thus generate a phase diagram at a temperature (T). Using oxygen as an example, this is done according to
 
 .. math::
-    \gamma_{Surf} = \frac{1}{2A} \Bigg( E_{TiO_2}^{slab} - \frac{nTi_{Slab}}{nTi_{Bulk}} E_{TiO_2}^{Bulk} \Bigg) - \Gamma_O \mu_O - \Gamma_{H_2O} \mu_{H_2O} - n_O \mu_O (T) - n_{H_2O} \mu_{H_2O} (T) 
+    \gamma_{Surf} = \frac{1}{2A} \Bigg( E_{TiO_2}^{slab} - \frac{nTi_{Slab}}{nTi_{Bulk}} E_{TiO_2}^{Bulk} \Bigg) - \Gamma_O \mu_O - \Gamma_{H_2O} \mu_{H_2O} - n_O \mu_O (T) - n_{H_2O} \mu_{H_2O} (T)
 
-where 
+where
 
 .. math::
     \mu_O (T)  = \frac{1}{2} \mu_O (T) (0 K , DFT) +  \frac{1}{2} \mu_O (T) (0 K , EXP) +  \frac{1}{2} \Delta G_{O_2} ( \Delta T, Exp),
 
-:math:`\mu_O` (T) (0 K , DFT) is the 0K free energy of an isolated oxygen molecule evaluated with DFT, :math:`\mu_O` (T) (0 K , EXP) is the 0 K experimental 
+:math:`\mu_O` (T) (0 K , DFT) is the 0K free energy of an isolated oxygen molecule evaluated with DFT, :math:`\mu_O` (T) (0 K , EXP) is the 0 K experimental
 Gibbs energy for oxygen gas and $\Delta$ :math:`G_{O_2}` ( :math:`\Delta` T, Exp) is the Gibbs energy defined at temperature T as
 
 .. math::
     \Delta G_{O_2} ( \Delta T, Exp)  = \frac{1}{2} [H(T, {O_2}) -  H(0 K, {O_2})] -  \frac{1}{2} T[S(T, {O_2}])
 
-`surfinpy` has a built in function to read a NIST_JANAF table and calculate this temperature_correction for you. In the following example you will also 
+`surfinpy` has a built in function to read a NIST_JANAF table and calculate this temperature_correction for you. In the following example you will also
 see an example of how you can tweak the style and colourmap of the plot.
 
 .. code-block:: python
@@ -138,13 +138,13 @@ see an example of how you can tweak the style and colourmap of the plot.
     Oxygen_exp = mu_vs_mu.temperature_correction("O2.txt", 298)
     Water_exp = mu_vs_mu.temperature_correction("H2O.txt", 298)
 
-    Oxygen_corrected = (-9.08 + -0.86 + Oxygen_exp) 
+    Oxygen_corrected = (-9.08 + -0.86 + Oxygen_exp)
     Water_corrected = -14.84 + 0.55 + Water_exp
 
-    system =  mu_vs_mu.calculate(data, bulk, deltaX, deltaY, 
-                                 x_energy=Oxygen_corrected, 
+    system =  mu_vs_mu.calculate(data, bulk, deltaX, deltaY,
+                                 x_energy=Oxygen_corrected,
                                  y_energy=Water_corrected)
-    system.plot_phase(temperature=298, set_style="fast", 
+    system.plot_phase(temperature=298, set_style="fast",
                       colourmap="RdBu")
 
 .. image:: Figures/Tutorial_1/Second.png
@@ -160,7 +160,7 @@ The chemical potential can be converted to pressure values according to
 .. math::
     P = \frac{\mu_O}{k_B T}
 
-where P is the pressure, :math:`\mu` is the chemical potential of oxygen, :math:`k_B` is the Boltzmnann constant and T is the temperature. 
+where P is the pressure, :math:`\mu` is the chemical potential of oxygen, :math:`k_B` is the Boltzmann constant and T is the temperature.
 
 
 .. code-block:: python
@@ -170,13 +170,13 @@ where P is the pressure, :math:`\mu` is the chemical potential of oxygen, :math:
     Oxygen_exp = mu_vs_mu.temperature_correction("O2.txt", 298)
     Water_exp = mu_vs_mu.temperature_correction("H2O.txt", 298)
 
-    Oxygen_corrected = (-9.08 + -0.86 + Oxygen_exp) 
+    Oxygen_corrected = (-9.08 + -0.86 + Oxygen_exp)
     Water_corrected = -14.84 + 0.55 + Water_exp
 
-    system =  mu_vs_mu.calculate(data, bulk, deltaX, deltaY, 
-                                 x_energy=Oxygen_corrected, 
+    system =  mu_vs_mu.calculate(data, bulk, deltaX, deltaY,
+                                 x_energy=Oxygen_corrected,
                                  y_energy=Water_corrected)
-    system.plot_mu_p(output="Example_ggrd", colourmap="RdYlGn", 
+    system.plot_mu_p(output="Example_ggrd", colourmap="RdYlGn",
                      temperature=298)
 
 .. image:: Figures/Tutorial_1/Third.png
@@ -185,9 +185,9 @@ where P is the pressure, :math:`\mu` is the chemical potential of oxygen, :math:
 
 .. code-block:: python
 
-    system.plot_mu_p(output="Example_ggrd", 
-                     set_style="dark_background", 
-                     colourmap="RdYlGn", 
+    system.plot_mu_p(output="Example_ggrd",
+                     set_style="dark_background",
+                     colourmap="RdYlGn",
                      temperature=298)
 
 .. image:: Figures/Tutorial_1/Fourth.png
@@ -196,9 +196,9 @@ where P is the pressure, :math:`\mu` is the chemical potential of oxygen, :math:
 
 .. code-block:: python
 
-    system.plot_pressure(output="Example_dark_rdgn", 
-                         set_style="dark_background", 
-                         colourmap="PuBu", 
+    system.plot_pressure(output="Example_dark_rdgn",
+                         set_style="dark_background",
+                         colourmap="PuBu",
                          temperature=298)
 
 .. image:: Figures/Tutorial_1/Filth.png

--- a/docs/source/tutorial_2.rst
+++ b/docs/source/tutorial_2.rst
@@ -1,19 +1,19 @@
 Pressure vs Temperature
 =======================
 
-`Surfinpy` has the functionality to generate phase diagrams as a function of pressure vs temperature based upon the methodology used in `Molinari et al 
+`Surfinpy` has the functionality to generate phase diagrams as a function of pressure vs temperature based upon the methodology used in `Molinari et al
 <https://pubs.acs.org/doi/abs/10.1021/jp300576b>`_ according to
 
 .. math::
     \gamma_{adsorbed, T, P} = \gamma_{bare} + ( C ( E_{ads, T} - RTln(\frac{p}{p^o})
 
-where :math:`\gamma_{adsorbed, T, p}` is the surface energy of the surface with adsorbed species at temperature (T) and pressure (P), 
-:math:`\gamma_{bare}` is the suface energy of the bare surface, C is the coverage of adsorbed species, :math:`E_{ads}` is the adsorption energy, 
+where :math:`\gamma_{adsorbed, T, p}` is the surface energy of the surface with adsorbed species at temperature (T) and pressure (P),
+:math:`\gamma_{bare}` is the surface energy of the bare surface, C is the coverage of adsorbed species, :math:`E_{ads}` is the adsorption energy,
 
 .. math::
     E_{ads, T} =  E_{slab, adsorbant} - (E_{slab, bare} + n_{H_2O} E_{H_2O, T}) / n_{H_2O}
 
-where :math:`E_{slab, adsorbant}` is the energy of the surface and the adsorbed species, :math:`n_{H_2O}` is he number of adsorbed species, 
+where :math:`E_{slab, adsorbant}` is the energy of the surface and the adsorbed species, :math:`n_{H_2O}` is he number of adsorbed species,
 
 .. math::
     E_{H_2O, (T)} = E_{H_2O, (g)} - TS_{(T)}
@@ -33,9 +33,9 @@ Usage
 
     stoich = {'Cation': 24, 'X': 48, 'Y': 0, 'Area': 60.22,
               'Energy': -575.00, 'Label': 'Bare'}
-    H2O =    {'Cation': 24, 'X': 48, 'Y': 2, 'Area': 60.22, 
+    H2O =    {'Cation': 24, 'X': 48, 'Y': 2, 'Area': 60.22,
               'Energy': -605.00, 'Label': '1 Water'}
-    H2O_2 =  {'Cation': 24, 'X': 48, 'Y': 8, 'Area': 60.22, 
+    H2O_2 =  {'Cation': 24, 'X': 48, 'Y': 8, 'Area': 60.22,
               'Energy': -695.00, 'Label': '2 Water'}
     data = [H2O, H2O_2]
 
@@ -43,9 +43,9 @@ Usage
 
     thermochem = ut.read_nist("H2O.txt")
 
-    system = p_vs_t.calculate(stoich, data, SE, 
-                              adsorbant, 
-                              thermochem, 
+    system = p_vs_t.calculate(stoich, data, SE,
+                              adsorbant,
+                              thermochem,
                               coverage)
     system.plot()
 
@@ -58,7 +58,7 @@ Alternatively you can also tweak the style
 
 .. code-block:: python
 
-    system.plot(output="dark_pvt.png", 
+    system.plot(output="dark_pvt.png",
                 set_style="dark_background",
                 colourmap="PiYG")
 

--- a/docs/source/tutorial_3.rst
+++ b/docs/source/tutorial_3.rst
@@ -1,27 +1,27 @@
 Particle Morphology
 ===================
 
-It is sometimes useful to use surface energies in order to generate particle morphologies. 
-This tutorial demonstrates how to obtain surface energies for surfaces containing adsorbed species using `surfinpy`. 
-With these you can then generate a wulff construction using `pymatgen <https://www.sciencedirect.com/science/article/pii/S0927025612006295?via%3Dihub>`_. 
-A Wulff construction is a method to determine the equilibrium shape of a crystal. 
+It is sometimes useful to use surface energies in order to generate particle morphologies.
+This tutorial demonstrates how to obtain surface energies for surfaces containing adsorbed species using `surfinpy`.
+With these you can then generate a wulff construction using `pymatgen <https://www.sciencedirect.com/science/article/pii/S0927025612006295?via%3Dihub>`_.
+A Wulff construction is a method to determine the equilibrium shape of a crystal.
 So by calculating the surface energies of multiple different surfaces, at different temperature and pressure values we can generate a particle morphology for the material,
-in the prescence of an adsorbing species, at a specific temperature and pressure. 
+in the presence of an adsorbing species, at a specific temperature and pressure.
 
-`surfinpy` has a module called wulff that will return a surface energy at a given temperature and pressure value. 
-These can then be used in conjunction with Pymatgen for a wulff construction. 
-So first we need to declare the data for each surface and calculate the surface energies. 
-As an aside, it is possible to provide multiple coverages, the return will be an array of surface energies, 
+`surfinpy` has a module called wulff that will return a surface energy at a given temperature and pressure value.
+These can then be used in conjunction with Pymatgen for a wulff construction.
+So first we need to declare the data for each surface and calculate the surface energies.
+As an aside, it is possible to provide multiple coverages, the return will be an array of surface energies,
 corresponding to each surface coverage, you would then select the minimum value with `np.amin()`
 
 .. code-block:: python
 
     import numpy as np
     from surfinpy import p_vs_t as pt
-    from surfinpy import wulff  
+    from surfinpy import wulff
     from surfinpy import utils as ut
-    from pymatgen.core.surface import SlabGenerator, 
-                                      generate_all_slabs, 
+    from pymatgen.core.surface import SlabGenerator,
+                                      generate_all_slabs,
                                       Structure, Lattice
     from pymatgen.analysis.wulff import WulffShape
 
@@ -33,45 +33,45 @@ The first thing to do is calculate the surface energy at a temperature and press
 .. code-block:: python
 
     SE = 1.44
-    stoich =      {'M': 24, 'X': 48, 'Y': 0, 'Area': 60.22, 
+    stoich =      {'M': 24, 'X': 48, 'Y': 0, 'Area': 60.22,
                   'Energy': -575.66, 'Label': 'Stoich'}
-    Adsorbant_1 = {'M': 24, 'X': 48, 'Y': 2, 'Area': 60.22, 
+    Adsorbant_1 = {'M': 24, 'X': 48, 'Y': 2, 'Area': 60.22,
                    'Energy': -609.23, 'Label': '1 Species'}
     data = [Adsorbant_1]
-    Surface_100_1 = wulff.calculate_surface_energy(stoich, 
-                                                   data, 
-                                                   SE, 
-                                                   adsorbant, 
-                                                   thermochem, 
-                                                   298, 
+    Surface_100_1 = wulff.calculate_surface_energy(stoich,
+                                                   data,
+                                                   SE,
+                                                   adsorbant,
+                                                   thermochem,
+                                                   298,
                                                    0)
 
     SE = 1.06
-    stoich =      {'M': 24, 'X': 48, 'Y': 0, 'Area': 85.12, 
+    stoich =      {'M': 24, 'X': 48, 'Y': 0, 'Area': 85.12,
                    'Energy': -672.95, 'Label': 'Stoich'}
-    Adsorbant_1 = {'M': 24, 'X': 48, 'Y': 2, 'Area': 85.12, 
+    Adsorbant_1 = {'M': 24, 'X': 48, 'Y': 2, 'Area': 85.12,
                    'Energy': -705.0, 'Label': '1 Species'}
     data = [Adsorbant_1]
-    Surface_110_1 = wulff.calculate_surface_energy(stoich, 
-                                                   data, 
-                                                   SE, 
-                                                   adsorbant, 
-                                                   thermochem, 
-                                                   298, 
+    Surface_110_1 = wulff.calculate_surface_energy(stoich,
+                                                   data,
+                                                   SE,
+                                                   adsorbant,
+                                                   thermochem,
+                                                   298,
                                                    0)
 
     SE = 0.76
-    stoich =      {'M': 24, 'X': 48, 'Y': 0, 'Area': 77.14, 
+    stoich =      {'M': 24, 'X': 48, 'Y': 0, 'Area': 77.14,
                    'Energy': -579.61, 'Label': 'Stoich'}
-    Adsorbant_1 = {'M': 24, 'X': 48, 'Y': 2, 'Area': 77.14, 
+    Adsorbant_1 = {'M': 24, 'X': 48, 'Y': 2, 'Area': 77.14,
                    'Energy': -609.24, 'Label': '1 Species'}
     data = [Adsorbant_1]
-    Surface_111_1 = wulff.calculate_surface_energy(stoich, 
-                                                   data, 
-                                                   SE, 
-                                                   adsorbant, 
-                                                   thermochem, 
-                                                   298, 
+    Surface_111_1 = wulff.calculate_surface_energy(stoich,
+                                                   data,
+                                                   SE,
+                                                   adsorbant,
+                                                   thermochem,
+                                                   298,
                                                    0)
 
 The with these surface energies we can build a particle morphology using pymatgen
@@ -81,8 +81,8 @@ The with these surface energies we can build a particle morphology using pymatge
     lattice = Lattice.cubic(5.411)
     ceo = Structure(lattice,["Ce", "O"],
                    [[0,0,0], [0.25,0.25,0.25]])
-    surface_energies_ceo = {(1,1,1): np.amin(Surface_111_1), 
-                            (1,1,0): np.amin(Surface_110_1), 
+    surface_energies_ceo = {(1,1,1): np.amin(Surface_111_1),
+                            (1,1,0): np.amin(Surface_110_1),
                             (1,0,0): np.amin(Surface_100_1)}
 
     miller_list = surface_energies_ceo.keys()

--- a/docs/source/tutorial_4.rst
+++ b/docs/source/tutorial_4.rst
@@ -1,7 +1,7 @@
 Chemical Potential
 ==================
 
-In this tutorial we learn how to generate a basic bulk phase diagram from DFT energies.  This enables the comparison of the thermodynamic stability of various different bulk phases under different chemical potentials giving valuable insight in to the syntheis of solid phases.  This example will consider a series of bulk phases which can be defined through a reaction scheme across all phases, thus for this example including Bulk, :math:`H_2O` and :math:`CO_2` as reactions and A as a generic product.
+In this tutorial we learn how to generate a basic bulk phase diagram from DFT energies.  This enables the comparison of the thermodynamic stability of various different bulk phases under different chemical potentials giving valuable insight in to the synthesis of solid phases.  This example will consider a series of bulk phases which can be defined through a reaction scheme across all phases, thus for this example including Bulk, :math:`H_2O` and :math:`CO_2` as reactions and A as a generic product.
 
 .. math::
     x\text{Bulk} + y\text{H}_2\text{O} + z\text{CO}_2 \rightarrow \text{A}
@@ -17,7 +17,7 @@ Assuming that :math:`H_2O` and :math:`CO_2` are gaseous species, :math:`$\mu_{CO
 .. math::
 	\mu_{\text{H}_2\text{O}} = \mu^0_{\text{H}_2\text{O}} + \Delta\mu_{\text{H}_2\text{O}}
 
-and 
+and
 
 .. math::
 	\mu_{\text{CO}_2} = \mu^0_{\text{CO}_2} + \Delta\mu_{\text{CO}_2}
@@ -80,14 +80,14 @@ Next we create the bulk phases classes - one for each phase (A-F). 'Cation' is t
     F = data.DataSet(cation = 10, x = 8, y = 10, energy = -398.0, label = "F")
 
 
-Next we need to create a list of our data. Don't worry about the order, `surfinpy` will sort that out for you. 
+Next we need to create a list of our data. Don't worry about the order, `surfinpy` will sort that out for you.
 
 .. code-block:: python
 
     data = [Bulk, A, B, C,  D, E, F]
 
 
-We now need to generate our X and Y axis, or more appropriately, our chemical potential values. These exist in a dictionary. 'Range' corresponds to the range of chemcial potential values to be considered and 'Label' is the axis label.  Additionally, the x and y energy need to be specified.
+We now need to generate our X and Y axis, or more appropriately, our chemical potential values. These exist in a dictionary. 'Range' corresponds to the range of chemical potential values to be considered and 'Label' is the axis label.  Additionally, the x and y energy need to be specified.
 
 .. code-block:: python
 
@@ -103,7 +103,7 @@ We now need to generate our X and Y axis, or more appropriately, our chemical po
     y_energy=-12.83725889
 
 
-And finally we can generate our plot using these 6 variables of data. 
+And finally we can generate our plot using these 6 variables of data.
 
 .. code-block:: python
 
@@ -120,8 +120,8 @@ And finally we can generate our plot using these 6 variables of data.
 Temperature
 -----------
 
-In the previous example we generated a phase diagram at 0 K.  However, this is not representative of normal conditions.  
-Temperature is an important consideration for materials chemistry and we may wish to evaluate the phase thermodynamic stability at various synthesis conditions.  
+In the previous example we generated a phase diagram at 0 K.  However, this is not representative of normal conditions.
+Temperature is an important consideration for materials chemistry and we may wish to evaluate the phase thermodynamic stability at various synthesis conditions.
 This example will again be using the :math:`Bulk-CO_2-H_2O` system.
 
 As before the free energy can be calculated using;
@@ -129,9 +129,9 @@ As before the free energy can be calculated using;
 .. math::
     \Delta G^{0}_{f} = \sum\Delta G_{f}^{0,\text{products}} - \sum\Delta G_{f}^{0,\text{reactants}}
 
-Where for this tutorial the free energy (G) for solid phases  is equal to is equal to the calculated DFT energy :math:`(U_0)`. 
-For gaseous species, the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems, 
-we use experimental data to determine the temperature dependent free energy term for gaseous species, 
+Where for this tutorial the free energy (G) for solid phases  is equal to is equal to the calculated DFT energy :math:`(U_0)`.
+For gaseous species, the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems,
+we use experimental data to determine the temperature dependent free energy term for gaseous species,
 where :math:`$S_{expt}(T)$` is specific entropy value for a given T and  :math:`$H-H^0(T)$` is the , both can be obtained from the NIST database and can be calculated as;
 
 .. math::
@@ -159,9 +159,9 @@ where :math:`$S_{expt}(T)$` is specific entropy value for a given T and  :math:`
     x_energy=-20.53412969
     y_energy=-12.83725889
 
-In order to calculate :math:`$S_{expt}(T)$` for :math:`H_2O` and :math:`CO_2` we need to use experimental data from the NSIT JANAF database.  
-As a user you will need to download the tables for the species you are interested in (in this example water and carbon dioxide).  
-`surfinpy` has a function that can read this data, assuming it is in the correct format and calculate the temperature correction for you.  
+In order to calculate :math:`$S_{expt}(T)$` for :math:`H_2O` and :math:`CO_2` we need to use experimental data from the NSIT JANAF database.
+As a user you will need to download the tables for the species you are interested in (in this example water and carbon dioxide).
+`surfinpy` has a function that can read this data, assuming it is in the correct format and calculate the temperature correction for you.
 Provide the path to the file and the temperature you want.
 
 .. code-block:: python
@@ -175,7 +175,7 @@ Provide the path to the file and the temperature you want.
     deltaX = {'Range': [ -3, 2],  'Label': 'CO_2'}
     deltaY = {'Range': [ -3, 2], 'Label': 'H_2O'}
 
-CO2_corrected and H2O_corrected are now temperature depenent terms correcsponding to a temperature of 298 K. The resulting phase diagram will now be at a temperature of 298 K.
+CO2_corrected and H2O_corrected are now temperature dependent terms corresponding to a temperature of 298 K. The resulting phase diagram will now be at a temperature of 298 K.
 
 .. code-block:: python
 
@@ -190,15 +190,15 @@ CO2_corrected and H2O_corrected are now temperature depenent terms correcspondin
 Pressure
 --------
 
-In the previous example we went through the process of generating a simple phase diagram for bulk phases and introducing temperature dependence for gaseous species.  
-This useful however, sometimes it can be more beneficial to convert the chemical potenials (eVs) to partial presure (bar). 
+In the previous example we went through the process of generating a simple phase diagram for bulk phases and introducing temperature dependence for gaseous species.
+This useful however, sometimes it can be more beneficial to convert the chemical potentials (eVs) to partial pressure (bar).
 
 Chemical potential can be converted to pressure values using
 
 .. math::
     P & = \frac{\mu_O}{k_B T} ,
 
-where P is the pressure, :math:`$\mu$` is the chemical potential of oxygen, $k_B$ is the Boltzmnann constant and T is the temperature. 
+where P is the pressure, :math:`$\mu$` is the chemical potential of oxygen, $k_B$ is the Boltzmann constant and T is the temperature.
 
 .. code-block:: python
 
@@ -210,7 +210,7 @@ where P is the pressure, :math:`$\mu$` is the chemical potential of oxygen, $k_B
     colors = ['#5B9BD5', '#4472C4', '#A5A5A5', '#772C24', '#ED7D31', '#FFC000', '#70AD47']
 
 
-Additionally, `surfinpy` has the functionality to allow you to choose which colours are used for each phase.  Specify within the DataSet class color. 
+Additionally, `surfinpy` has the functionality to allow you to choose which colours are used for each phase.  Specify within the DataSet class color.
 
 .. code-block:: python
 

--- a/docs/source/tutorial_5.rst
+++ b/docs/source/tutorial_5.rst
@@ -1,8 +1,8 @@
 Pressure vs Temperature
 =======================
 
-In the previous example, we showed how experimental data could be used to determine the temperature dependent free energy term for gaseous species and then plot a phase diagram that represents 298 K.  
-This same method can be used in conjuction with a temperature range to produce a phase diagram of temperature as a function of pressure (or chemical potential).  
+In the previous example, we showed how experimental data could be used to determine the temperature dependent free energy term for gaseous species and then plot a phase diagram that represents 298 K.
+This same method can be used in conjunction with a temperature range to produce a phase diagram of temperature as a function of pressure (or chemical potential).
 This is an important step to producing relatable phase diagrams that can be compared to experimental findings.
 
 To reiterate, the free energy can be calculated using;
@@ -10,9 +10,9 @@ To reiterate, the free energy can be calculated using;
 .. math::
     \Delta G^{0}_{f} = \sum\Delta G_{f}^{0,\text{products}} - \sum\Delta G_{f}^{0,\text{reactants}}
 
-Where for this tutorial the free energy (G) for solid phases  is equal to is equal to the calculated DFT energy (:math:`U_0`). For gaseous species, 
-the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems, 
-we use experimental data to determine the temperature dependent free energy term for gaseous species, where $S_{\text{expt}}(T)$ is specific entropy value for a given T and  $H-H^0(T)$ is the , 
+Where for this tutorial the free energy (G) for solid phases  is equal to is equal to the calculated DFT energy (:math:`U_0`). For gaseous species,
+the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems,
+we use experimental data to determine the temperature dependent free energy term for gaseous species, where $S_{\text{expt}}(T)$ is specific entropy value for a given T and  $H-H^0(T)$ is the ,
 both can be obtained from the NIST database and can be calculated as;
 
 .. math::
@@ -41,37 +41,37 @@ temperature_range sets the temperature range which is calculated for the phase d
 
 
     Bulk = data.DataSet(cation = 10, x = 0, y = 0, energy = -92., color=colors[0],
-                    label = "Bulk", file = 'ref_files/bulk_vib.yaml'', 
+                    label = "Bulk", file = 'ref_files/bulk_vib.yaml'',
                     funits = 10, temp_range=temperature_range)
 
     D = data.DataSet(cation = 10, x = 10, y = 0, energy = -310.,  color=colors[1],
-                    label = "D", file = 'ref_files/D_vib.yaml', 
+                    label = "D", file = 'ref_files/D_vib.yaml',
                     funits =  10, temp_range=temperature_range)
 
     B = data.DataSet(cation = 10, x = 0, y = 10, energy = -227.,  color=colors[2],
-                    label = "B", file = 'ref_files/B_vib.yaml', 
+                    label = "B", file = 'ref_files/B_vib.yaml',
                     funits =  10, temp_range=temperature_range)
 
     F = data.DataSet(cation = 10, x = 8, y = 10, energy = -398.,  color=colors[3],
-                    label = "F", file = 'ref_files/F_vib.yaml', 
+                    label = "F", file = 'ref_files/F_vib.yaml',
                     funits =  2, temp_range=temperature_range)
 
     A = data.DataSet(cation = 10, x = 5, y = 20, energy = -467.,  color=colors[4],
-                    label = "A", file = 'ref_files/A_vib.yaml', 
+                    label = "A", file = 'ref_files/A_vib.yaml',
                     funits = 5, temp_range=temperature_range)
 
     C = data.DataSet(cation = 10, x = 10, y = 30, energy = -705.,  color=colors[5],
-                    label = "C", file = 'ref_files/C_vib.yaml', 
+                    label = "C", file = 'ref_files/C_vib.yaml',
                     funits = 10, temp_range=temperature_range)
 
     E = data.DataSet(cation = 10, x = 10, y = 50, energy = -971.,  color=colors[6],
-                    label = "E", file = 'ref_files/E_vib.yaml', 
+                    label = "E", file = 'ref_files/E_vib.yaml',
                     funits =  10, temp_range=temperature_range)
 
     data = [Bulk, A, B, C,  D, E, F]
 
-deltaZ specifies the temperature range which is plotted (Note that this must be the same as temperature_range).  
-mu_y is the chemical potential (eV) of third component, in this example we use a chemical potential of water = 0 eV which is equivalent to 1 bar pressure. 
+deltaZ specifies the temperature range which is plotted (Note that this must be the same as temperature_range).
+mu_y is the chemical potential (eV) of third component, in this example we use a chemical potential of water = 0 eV which is equivalent to 1 bar pressure.
 
 .. code-block:: python
 

--- a/docs/source/tutorial_6.rst
+++ b/docs/source/tutorial_6.rst
@@ -1,11 +1,11 @@
 Vibrational Entropy
 ===================
 
-In this example we will expand this methodology to calculate the vibrational properties for solid phases (i.e. zero point energy, vibrational entropy) 
+In this example we will expand this methodology to calculate the vibrational properties for solid phases (i.e. zero point energy, vibrational entropy)
 and include these values in the generation of the phase diagrams.  This allows for a more accurate calculation of phase diagrams without the need to include experimental corrections for solid phases.
 
-As with previous examples, the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems, 
-we use experimental data to determine the temperature dependent free energy term for gaseous species obtained from the NIST database.  
+As with previous examples, the standard free energy varies significantly with temperature, and as DFT simulations are designed for condensed phase systems,
+we use experimental data to determine the temperature dependent free energy term for gaseous species obtained from the NIST database.
 In addition we also calculate the vibrational properties for the solid phases modifying the free energy (G) for solid phases to be;
 
 .. math::
@@ -38,45 +38,45 @@ where :math:`$A_{vib}$` is the vibrational Helmholtz free energy and defined as;
     bulk = data.ReferenceDataSet(cation = 1, anion = 1, energy = -92.0, funits = 10, file = 'bulk_vib.yaml', entropy=True, zpe=True, temp_range=temperature_range)
 
 
-In addition to entropy and zpe keyword you must provide the a file containing the vibrational modes and number of formula units used in taht calculations.  You must create the yaml file using the following format
+In addition to entropy and zpe keyword you must provide the a file containing the vibrational modes and number of formula units used in that calculations.  You must create the yaml file using the following format
 
 .. code-block:: python
 
     F-Units : number
-    Frequencies : 
+    Frequencies :
     - mode1
     - mode2
 
-Vibrational modes can be calculated via a density functional pertibation calculation or via the phonopy code.
+Vibrational modes can be calculated via a density functional perturbation calculation or via the phonopy code.
 
 .. code-block:: python
 
-    Bulk = data.DataSet(cation = 10, x = 0, y = 0, energy = -92, 
-                      label = "Bulk", entropy = True, zpe=True, file = 'ref_files/bulk_vib.yaml', 
+    Bulk = data.DataSet(cation = 10, x = 0, y = 0, energy = -92,
+                      label = "Bulk", entropy = True, zpe=True, file = 'ref_files/bulk_vib.yaml',
                       funits = 10, temp_range=temperature_range)
 
-    A = data.DataSet(cation = 10, x = 5, y = 20, energy = -468, 
-                      label = "A", entropy = True, zpe=True, file = 'ref_files/A_vib.yaml', 
+    A = data.DataSet(cation = 10, x = 5, y = 20, energy = -468,
+                      label = "A", entropy = True, zpe=True, file = 'ref_files/A_vib.yaml',
                       funits = 5, temp_range=temperature_range)
 
-    B = data.DataSet(cation = 10, x = 0, y = 10, energy = -228, 
-                      label = "B", entropy = True, zpe=True, file = 'ref_files/B_vib.yaml', 
+    B = data.DataSet(cation = 10, x = 0, y = 10, energy = -228,
+                      label = "B", entropy = True, zpe=True, file = 'ref_files/B_vib.yaml',
                       funits =  10, temp_range=temperature_range)
 
-    C = data.DataSet(cation = 10, x = 10, y = 30, energy = -706, 
-                      label = "C", entropy = True, zpe=True, file = 'ref_files/C_vib.yaml', 
+    C = data.DataSet(cation = 10, x = 10, y = 30, energy = -706,
+                      label = "C", entropy = True, zpe=True, file = 'ref_files/C_vib.yaml',
                       funits = 10, temp_range=temperature_range)
 
-    D = data.DataSet(cation = 10, x = 10, y = 0, energy = -310, 
-                      label = "D", entropy = True, zpe=True,  file = 'ref_files/D_vib.yaml', 
+    D = data.DataSet(cation = 10, x = 10, y = 0, energy = -310,
+                      label = "D", entropy = True, zpe=True,  file = 'ref_files/D_vib.yaml',
                       funits =  10, temp_range=temperature_range)
 
-    E = data.DataSet(cation = 10, x = 10, y = 50, energy = -972, 
-                      label = "E", entropy = True, zpe=True, file = 'ref_files/E_vib.yaml', 
+    E = data.DataSet(cation = 10, x = 10, y = 50, energy = -972,
+                      label = "E", entropy = True, zpe=True, file = 'ref_files/E_vib.yaml',
                       funits =  10, temp_range=temperature_range)
 
-    F = data.DataSet(cation = 10, x = 8, y = 10, energy = -398, 
-                      label = "F", entropy = True, zpe=True, file = 'ref_files/F_vib.yaml', 
+    F = data.DataSet(cation = 10, x = 8, y = 10, energy = -398,
+                      label = "F", entropy = True, zpe=True, file = 'ref_files/F_vib.yaml',
                       funits =  2, temp_range=temperature_range)
 
 
@@ -106,7 +106,7 @@ Vibrational modes can be calculated via a density functional pertibation calcula
 Temperature
 -----------
 
-In tutorial 5 we showed how SurfinPy can be used to calculate the vibrational entropy and zero point energy for solid phases and in tutorial 4 we showed how a temperature range can be used to calculate the phase diagram of temperature as a function of presure.  In this example we will use both lesson from these tutorials to produce a phase diagram of temperature as a function of pressure including the vibrational properties for solid phases.  Again this produces results which are easily compared to experimental values in addition to increasing the level of theory used.
+In tutorial 5 we showed how SurfinPy can be used to calculate the vibrational entropy and zero point energy for solid phases and in tutorial 4 we showed how a temperature range can be used to calculate the phase diagram of temperature as a function of pressure.  In this example we will use both lesson from these tutorials to produce a phase diagram of temperature as a function of pressure including the vibrational properties for solid phases.  Again this produces results which are easily compared to experimental values in addition to increasing the level of theory used.
 
 .. code-block:: python
 
@@ -125,32 +125,32 @@ In tutorial 5 we showed how SurfinPy can be used to calculate the vibrational en
 
 
     Bulk = data.DataSet(cation = 10, x = 0, y = 0, energy = -92., color=colors[0],
-                    label = "Bulk", entropy = True, zpe=True, file = 'ref_files/bulk_vib.yaml', 
+                    label = "Bulk", entropy = True, zpe=True, file = 'ref_files/bulk_vib.yaml',
                     funits = 10, temp_range=temperature_range)
 
     D = data.DataSet(cation = 10, x = 10, y = 0, energy = -310.,  color=colors[1],
-                    label = "D", entropy = True, zpe=True,  file = 'ref_files/D_vib.yaml', 
+                    label = "D", entropy = True, zpe=True,  file = 'ref_files/D_vib.yaml',
                     funits =  10, temp_range=temperature_range)
 
     B = data.DataSet(cation = 10, x = 0, y = 10, energy = -227.,  color=colors[2],
-                    label = "B", entropy = True, zpe=True, file = 'ref_files/B_vib.yaml', 
+                    label = "B", entropy = True, zpe=True, file = 'ref_files/B_vib.yaml',
                     funits =  10, temp_range=temperature_range)
 
     F = data.DataSet(cation = 10, x = 8, y = 10, energy = -398.,  color=colors[3],
-                    label = "F", entropy = True, zpe=True, file = 'ref_files/F_vib.yaml', 
-                    funits =  2, temp_range=temperature_range)     
-                
+                    label = "F", entropy = True, zpe=True, file = 'ref_files/F_vib.yaml',
+                    funits =  2, temp_range=temperature_range)
+
     A = data.DataSet(cation = 10, x = 5, y = 20, energy = -467.,  color=colors[4],
-                    label = "A", entropy = True, zpe=True, file = 'ref_files/A_vib.yaml', 
+                    label = "A", entropy = True, zpe=True, file = 'ref_files/A_vib.yaml',
                     funits = 5, temp_range=temperature_range)
 
 
     C = data.DataSet(cation = 10, x = 10, y = 30, energy = -705.,  color=colors[5],
-                    label = "C", entropy = True, zpe=True, file = 'ref_files/C_vib.yaml', 
+                    label = "C", entropy = True, zpe=True, file = 'ref_files/C_vib.yaml',
                     funits = 10, temp_range=temperature_range)
 
     E = data.DataSet(cation = 10, x = 10, y = 50, energy = -971.,  color=colors[6],
-                    label = "E", entropy = True, zpe=True, file = 'ref_files/E_vib.yaml', 
+                    label = "E", entropy = True, zpe=True, file = 'ref_files/E_vib.yaml',
                     funits =  10, temp_range=temperature_range)
 
     data = [Bulk, A, B, C,  D, E, F]
@@ -172,7 +172,7 @@ In tutorial 5 we showed how SurfinPy can be used to calculate the vibrational en
     :height: 300px
     :align: center
 
-When investigating the phase diagram for certain systems it could be beneficial to remove a kinetically inhibited but thermodynamically stable phase to investigate the metastable phase diagram.  Within SurfinPy this can be acheived via recreating the data list without the phase in question then recalculating the phse diagram, as below.
+When investigating the phase diagram for certain systems it could be beneficial to remove a kinetically inhibited but thermodynamically stable phase to investigate the metastable phase diagram.  Within SurfinPy this can be achieved via recreating the data list without the phase in question then recalculating the phase diagram, as below.
 
 .. code-block:: python
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -2,8 +2,8 @@ Tutorials
 =========
 
 These tutorials are replicated in jupyter notebook form and contained within `examples <https://github.com/symmy596/SurfinPy/tree/master/examples/>`_.
-The accompanying python scripts are also included here. All of code examples within these tutorials can be found in 
-`examples/Scripts <https://github.com/symmy596/SurfinPy/tree/master/examples/Scripts>`_. 
+The accompanying python scripts are also included here. All of code examples within these tutorials can be found in
+`examples/Scripts <https://github.com/symmy596/SurfinPy/tree/master/examples/Scripts>`_.
 
 
 Surfaces


### PR DESCRIPTION
A really excellent documentation, but there seems a lot of copy-and-paste between theory and tutorials.

I found a few typos and instead of opening an issue I decided to send a patch. Also, removed some trailing whitespace due to editor settings.